### PR TITLE
Fix UDP knocking

### DIFF
--- a/knock
+++ b/knock
@@ -44,6 +44,9 @@ class Knocker(object):
             s.setblocking(False)
             s.connect_ex((self.host, port))
             select.select([s], [s], [s], self.timeout)
+            if self.use_udp:
+                s.send(b'')
+
             s.close()
 
             if self.delay and i != last_index:


### PR DESCRIPTION
Resolves #1 

UDP doesn't have a connection like TCP does so we need to send some data to the socket to do the actual knocking. Packet with empty data should do fine.
